### PR TITLE
👌 IMPROVE: HTML default tags

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+tests/fixtures/*.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See <https://executablebooks.github.io/markdown-it-dollarmath/> for a demonstrat
 
 Note there is a similar plugin [markdown-it-texmath](https://github.com/goessner/markdown-it-texmath).
 `markdown-it-dollarmath` package differs in that it is optimised for dollar math:
-it is more performant, handles backslash ``\\`` escaping properly, and allows for more configuration.
+it is more performant, handles backslash `\\` escaping properly, and allows for more configuration.
 
 ## Usage
 
@@ -33,16 +33,19 @@ import MarkdownIt from "markdown-it"
 import dollarmathPlugin from "markdown-it-dollarmath"
 
 const mdit = MarkdownIt().use(dollarmathPlugin, {
-    allow_space: true,
-    allow_digits: true,
-    double_inline: true,
-    allow_labels: true,
-    labelNormalizer: (label: string) => {
-        return label.replace(/[\s]+/g, "-")
-    }
-    renderer: renderToString,
-    optionsInline: { throwOnError: false, displayMode: false },
-    optionsBlock: { throwOnError: false, displayMode: true }
+  allow_space: true,
+  allow_digits: true,
+  double_inline: true,
+  allow_labels: true,
+  labelNormalizer(label) {
+    return label.replace(/[\s]+/g, "-")
+  },
+  renderer(content, { displayMode }) {
+    return renderToString(content, { displayMode, throwOnError: false })
+  },
+  labelRenderer(label) {
+    return `<a href="#${label}" class="mathlabel" title="Permalink to this equation">¶<a>`
+  }
 })
 const text = mdit.render("$a = 1$")
 ```
@@ -52,25 +55,29 @@ In the browser:
 ```html
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Example Page</title>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-        <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
-        <script src="https://unpkg.com/markdown-it-dollarmath"></script>
-    </head>
-    <body>
-        <div id="demo"></div>
-        <script>
-            const options = { 
-                renderer: katex.renderToString, 
-                optionsInline: { throwOnError: false, displayMode: false },
-                optionsBlock: { throwOnError: false, displayMode: true }
-            };
-            const text = window.markdownit().use(window.markdownitDollarmath, options).render("$a = 1$");
-            document.getElementById("demo").innerHTML = text
-        </script>
-    </body>
+  <head>
+    <title>Example Page</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+    <script src="https://unpkg.com/markdown-it-dollarmath"></script>
+  </head>
+  <body>
+    <div id="demo"></div>
+    <script>
+      const options = {
+        renderer: (content, { displayMode }) =>
+          katex.renderToString(content, { displayMode, throwOnError: false })
+      }
+      const text = markdownit()
+        .use(window.markdownitDollarmath, options)
+        .render("$a = 1$")
+      document.getElementById("demo").innerHTML = text
+    </script>
+  </body>
 </html>
 ```
 
@@ -115,12 +122,11 @@ This can be deployed by [GitHub Pages].
 [ci-link]: https://github.com/executablebooks/markdown-it--plugin-template/actions
 [npm-badge]: https://img.shields.io/npm/v/markdown-it-dollarmath.svg
 [npm-link]: https://www.npmjs.com/package/markdown-it-dollarmath
-
-[GitHub Actions]: https://docs.github.com/en/actions
-[GitHub Pages]: https://docs.github.com/en/pages
+[github actions]: https://docs.github.com/en/actions
+[github pages]: https://docs.github.com/en/pages
 [prettier]: https://prettier.io/
 [eslint]: https://eslint.org/
-[Jest]: https://facebook.github.io/jest/
-[Rollup]: https://rollupjs.org
+[jest]: https://facebook.github.io/jest/
+[rollup]: https://rollupjs.org
 [npm]: https://www.npmjs.com
 [unpkg]: https://unpkg.com/

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,13 +50,13 @@ d=4
 $$ (label)</textarea
         >
         <div class="options">
-          <input type="checkbox" id="allow_space" checked>
+          <input type="checkbox" id="allow_space" checked />
           <label for="allow_space">allow_space</label>
-          <input type="checkbox" id="allow_digits" checked>
+          <input type="checkbox" id="allow_digits" checked />
           <label for="allow_digits">allow_digits</label>
-          <input type="checkbox" id="double_inline" checked>
+          <input type="checkbox" id="double_inline" checked />
           <label for="double_inline">double_inline</label>
-          <input type="checkbox" id="allow_labels" checked>
+          <input type="checkbox" id="allow_labels" checked />
           <label for="allow_labels">allow_labels</label>
         </div>
         <div id="renderer" class="rendered"></div>
@@ -85,11 +85,11 @@ $$ (label)</textarea
           allow_digits: allow_digits.checked,
           double_inline: double_inline.checked,
           allow_labels: allow_labels.checked,
-          renderer: katex.renderToString,
-          optionsInline: { throwOnError: false, displayMode: false },
-          optionsBlock: { throwOnError: false, displayMode: true }
+          renderer(content, { displayMode }) {
+            return katex.renderToString(content, { displayMode, throwOnError: false })
+          }
         }
-        const md = window.markdownit().use(window.markdownitDollarmath, options)
+        const md = markdownit().use(markdownitDollarmath, options)
         renderer.innerHTML = md.render(inputText.value)
       }
       // trigger change handler for first render

--- a/docs/main.css
+++ b/docs/main.css
@@ -26,3 +26,12 @@
   outline: 1px solid lightgrey;
   min-height: 100px;
 }
+
+div.math.block {
+  width: calc(100% - 10px);
+}
+
+.mathlabel {
+  float: right;
+  transform: translate(10px, 0);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^19.0.0",
+        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@types/jest": "^26.0.23",
         "@types/katex": "^0.11.0",
@@ -1190,6 +1191,47 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-json/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -9611,6 +9653,40 @@
           "version": "0.0.39",
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
           "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        }
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/jest": "^26.0.23",
     "@types/katex": "^0.11.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ export default {
     babel({ babelHelpers: "bundled" }), // transpile ES6/7 code
     nodeResolve(), // resolve third party modules in node_modules
     terser(), // minify generated bundle
-    json()
+    json()  // import json files as modules
   ],
   output: [
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from "rollup-plugin-typescript2"
 import { babel } from "@rollup/plugin-babel"
 import commonjs from "@rollup/plugin-commonjs"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
+import json from "@rollup/plugin-json"
 
 import * as packageJson from "./package.json"
 
@@ -13,7 +14,8 @@ export default {
     commonjs(), // Convert CommonJS modules to ES6
     babel({ babelHelpers: "bundled" }), // transpile ES6/7 code
     nodeResolve(), // resolve third party modules in node_modules
-    terser() // minify generated bundle
+    terser(), // minify generated bundle
+    json()
   ],
   output: [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type MarkdownIt from "markdown-it/lib"
 import { escapeHtml } from "markdown-it/lib/common/utils"
-import Renderer from "markdown-it/lib/renderer"
+import type Renderer from "markdown-it/lib/renderer"
 import type StateBlock from "markdown-it/lib/rules_block/state_block"
 import type StateInline from "markdown-it/lib/rules_inline/state_inline"
 
@@ -61,7 +61,7 @@ export default function dollarmath_plugin(md: MarkdownIt, options?: IOptions): v
       try {
         res = fullOptions.renderer(content, { displayMode: opts.displayMode })
       } catch (err) {
-        res = md.utils.escapeHtml(`${content}:${err.message}`)
+        res = md.utils.escapeHtml(`${content}:${(err as Error).message}`)
       }
       const className = opts.inline ? "inline" : "block"
       const tag = opts.displayMode ? "div" : "span"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type MarkdownIt from "markdown-it/lib"
+import { escapeHtml } from "markdown-it/lib/common/utils"
+import Renderer from "markdown-it/lib/renderer"
 import type StateBlock from "markdown-it/lib/rules_block/state_block"
 import type StateInline from "markdown-it/lib/rules_inline/state_inline"
+
+export interface IRenderOptions {
+  displayMode: boolean
+  inline: boolean
+}
 
 export interface IOptions {
   /** Parse inline math when there is space after/before the opening/closing `$`, e.g. `$ a $` */
@@ -15,20 +22,24 @@ export interface IOptions {
   /** function to normalize the label, by default replaces whitespace with `-` */
   labelNormalizer?: (label: string) => string
   /** The render function for math content */
-  renderer?: (content: string, options?: { [key: string]: any }) => string
-  /** Options to parse to the render function, for inline math */
-  optionsInline?: { [key: string]: any }
-  /** Options to parse to the render function, for block math */
-  optionsBlock?: { [key: string]: any }
+  renderer?: (content: string, options: IRenderOptions) => string
+  /** The render function for label content */
+  labelRenderer?: (label: string) => string
 }
 
-const OptionDefaults: IOptions = {
+const OptionDefaults: Required<IOptions> = {
   allow_space: true,
   allow_digits: true,
   double_inline: true,
   allow_labels: true,
-  labelNormalizer: (label: string) => {
+  labelNormalizer(label) {
     return label.replace(/[\s]+/g, "-")
+  },
+  renderer(content) {
+    return escapeHtml(content)
+  },
+  labelRenderer(label) {
+    return `<a href="#${label}" class="mathlabel" title="Permalink to this equation">¶</a>`
   }
 }
 
@@ -41,70 +52,49 @@ export default function dollarmath_plugin(md: MarkdownIt, options?: IOptions): v
   md.inline.ruler.before("escape", "math_inline", math_inline_dollar(fullOptions))
   md.block.ruler.before("fence", "math_block", math_block_dollar(fullOptions))
 
-  const renderer = fullOptions?.renderer
-
-  if (renderer) {
-    md.renderer.rules["math_inline"] = (tokens, idx) => {
-      const content = tokens[idx].content
+  const createRule =
+    (opts: IRenderOptions, hasLabel: boolean): Renderer.RenderRule =>
+    (tokens, idx) => {
+      const content = tokens[idx].content.trim()
       let res: string
       try {
-        res = renderer(content, fullOptions?.optionsInline)
+        res = fullOptions.renderer(content, opts)
       } catch (err) {
         res = md.utils.escapeHtml(`${content}:${err.message}`)
       }
-      return res
-    }
-    md.renderer.rules["math_inline_double"] = (tokens, idx) => {
-      const content = tokens[idx].content
-      let res: string
-      try {
-        res = renderer(content, fullOptions?.optionsBlock)
-      } catch (err) {
-        res = md.utils.escapeHtml(`${content}:${err.message}`)
-      }
-      return res
-    }
-    md.renderer.rules["math_block"] = (tokens, idx) => {
-      const content = tokens[idx].content
-      let res: string
-      try {
-        res = renderer(content, fullOptions?.optionsBlock)
-      } catch (err) {
-        res = md.utils.escapeHtml(`${content}:${err.message}`)
-      }
-      return res
-    }
-    md.renderer.rules["math_block_label"] = (tokens, idx) => {
-      const content = tokens[idx].content
-      const label = tokens[idx].info
-      let res: string
-      try {
-        res = renderer(content, fullOptions?.optionsBlock)
-      } catch (err) {
-        res = md.utils.escapeHtml(`${content}:${err.message}`)
-      }
+      const className = opts.inline ? "inline" : "block"
+      const tag = opts.displayMode ? "div" : "span"
+      const newline = opts.inline ? "" : "\n"
+      const id = tokens[idx].info
+      const label = hasLabel ? `${fullOptions.labelRenderer(id)}` : ""
       return (
-        res +
-        `\n<a href="#${label}" class="mathlabel" title="Permalink to this equation">¶</a>\n`
+        [
+          `<${tag} ${id ? `id="${id}" ` : ""}class="math ${className}">`,
+          label,
+          res,
+          `</${tag}>`
+        ]
+          .filter(v => !!v)
+          .join(newline) + newline
       )
     }
-  } else {
-    // basic renderers for testing
-    md.renderer.rules["math_inline"] = (tokens, idx) => {
-      return `<eq>${tokens[idx].content}</eq>`
-    }
-    md.renderer.rules["math_inline_double"] = (tokens, idx) => {
-      return `<eqn>${tokens[idx].content}</eqn>`
-    }
-    md.renderer.rules["math_block"] = (tokens, idx) => {
-      return `<section>\n<eqn>${tokens[idx].content}</eqn>\n</section>\n`
-    }
-    md.renderer.rules["math_block_label"] = (tokens, idx) => {
-      const content = tokens[idx].content
-      const label = tokens[idx].info
-      return `<section>\n<eqn>${content}</eqn>\n<span class="eqno">(${label})</span>\n</section>\n`
-    }
-  }
+
+  md.renderer.rules["math_inline"] = createRule(
+    { displayMode: false, inline: true },
+    false
+  )
+  md.renderer.rules["math_inline_double"] = createRule(
+    { displayMode: true, inline: true },
+    false
+  )
+  md.renderer.rules["math_block"] = createRule(
+    { displayMode: true, inline: false },
+    false
+  )
+  md.renderer.rules["math_block_label"] = createRule(
+    { displayMode: true, inline: false },
+    true
+  )
 }
 
 /** Test if dollar is escaped */
@@ -150,7 +140,7 @@ function math_inline_dollar(
         - check if the previous character is a space (if not allow_space)
         - check if the next character is a digit (if not allow_digits)
     - Check empty content
-   * 
+   *
   */
   function math_inline_dollar_rule(state: StateInline, silent: boolean): boolean {
     if (state.src.charCodeAt(state.pos) !== 0x24 /* $ */) {

--- a/tests/fixtures.spec.ts
+++ b/tests/fixtures.spec.ts
@@ -38,9 +38,8 @@ describe("Parses basic", () => {
       allow_digits: false,
       double_inline: true,
       allow_labels: true,
-      renderer: renderToString,
-      optionsInline: { throwOnError: false, displayMode: false },
-      optionsBlock: { throwOnError: false, displayMode: true }
+      renderer: (content, { displayMode }) =>
+        renderToString(content, { throwOnError: false, displayMode })
     })
     let rendered = mdit.render(text)
     // remove styles

--- a/tests/fixtures/basic.md
+++ b/tests/fixtures/basic.md
@@ -16,35 +16,35 @@ single character inline equation. (valid=True)
 .
 $a$
 .
-<p><eq>a</eq></p>
+<p><span class="math inline">a</span></p>
 .
 
 inline equation with single greek character (valid=True)
 .
 $\\varphi$
 .
-<p><eq>\\varphi</eq></p>
+<p><span class="math inline">\\varphi</span></p>
 .
 
 simple equation starting and ending with numbers. (valid=True)
 .
 $1+1=2$
 .
-<p><eq>1+1=2</eq></p>
+<p><span class="math inline">1+1=2</span></p>
 .
 
 simple equation including special html character. (valid=True)
 .
 $1+1<3$
 .
-<p><eq>1+1<3</eq></p>
+<p><span class="math inline">1+1&lt;3</span></p>
 .
 
 equation including backslashes. (valid=True)
 .
 $a \\backslash$
 .
-<p><eq>a \\backslash</eq></p>
+<p><span class="math inline">a \\backslash</span></p>
 .
 
 use of currency symbol, i.e. digits before/after opening/closing (valid=True)
@@ -58,42 +58,42 @@ use of currency symbol (valid=True)
 .
 If you solve $1+2$ you get $3
 .
-<p>If you solve <eq>1+2</eq> you get $3</p>
+<p>If you solve <span class="math inline">1+2</span> you get $3</p>
 .
 
 inline fraction (valid=True)
 .
 $\\frac{1}{2}$
 .
-<p><eq>\\frac{1}{2}</eq></p>
+<p><span class="math inline">\\frac{1}{2}</span></p>
 .
 
 inline column vector (valid=True)
 .
 $\\begin{pmatrix}x\\\\y\\end{pmatrix}$
 .
-<p><eq>\\begin{pmatrix}x\\\\y\\end{pmatrix}</eq></p>
+<p><span class="math inline">\\begin{pmatrix}x\\\\y\\end{pmatrix}</span></p>
 .
 
 inline bold vector notation (valid=True)
 .
 ${\\tilde\\bold e}_\\alpha$
 .
-<p><eq>{\\tilde\\bold e}_\\alpha</eq></p>
+<p><span class="math inline">{\\tilde\\bold e}_\\alpha</span></p>
 .
 
 exponentiation (valid=True)
 .
 $a^{b}$
 .
-<p><eq>a^{b}</eq></p>
+<p><span class="math inline">a^{b}</span></p>
 .
 
 conjugate complex (valid=True)
 .
 $a^\*b$ with $a^\*$
 .
-<p><eq>a^\*b</eq> with <eq>a^\*</eq></p>
+<p><span class="math inline">a^\*b</span> with <span class="math inline">a^\*</span></p>
 .
 
 Inline multi-line (valid=True)
@@ -101,8 +101,8 @@ Inline multi-line (valid=True)
 a $a
 \not=1$ b
 .
-<p>a <eq>a
-\not=1</eq> b</p>
+<p>a <span class="math inline">a
+\not=1</span> b</p>
 .
 
 Inline multi-line with newline (valid=False)
@@ -119,28 +119,28 @@ single block equation, greek index (valid=True)
 .
 $$e_\\alpha$$
 .
-<section>
-<eqn>e_\\alpha</eqn>
-</section>
+<div class="math block">
+e_\\alpha
+</div>
 .
 
 display equation on its own single line. (valid=True)
 .
-$$1+1=2$$   
+$$1+1=2$$
 .
-<section>
-<eqn>1+1=2</eqn>
-</section>
+<div class="math block">
+1+1=2
+</div>
 .
 
 display equation with number on its own single line. (valid=True)
 .
-$$1+1=2$$ (2)  
+$$1+1=2$$ (2)
 .
-<section>
-<eqn>1+1=2</eqn>
-<span class="eqno">(2)</span>
-</section>
+<div id="2" class="math block">
+<a href="#2" class="mathlabel" title="Permalink to this equation">¶</a>
+1+1=2
+</div>
 .
 
 inline equation followed by block equation. (valid=True)
@@ -149,19 +149,19 @@ ${e}_x$
 
 $$e_\\alpha$$
 .
-<p><eq>{e}_x</eq></p>
-<section>
-<eqn>e_\\alpha</eqn>
-</section>
+<p><span class="math inline">{e}_x</span></p>
+<div class="math block">
+e_\\alpha
+</div>
 .
 
 underline tests (valid=True)
 .
 $$c{\\bold e}_x = a{\\bold e}_\\alpha - b\\tilde{\\bold e}_\\alpha$$
 .
-<section>
-<eqn>c{\\bold e}_x = a{\\bold e}_\\alpha - b\\tilde{\\bold e}_\\alpha</eqn>
-</section>
+<div class="math block">
+c{\\bold e}_x = a{\\bold e}_\\alpha - b\\tilde{\\bold e}_\\alpha
+</div>
 .
 
 non-numeric character before opening $ or
@@ -171,30 +171,30 @@ a$1+1=2$
 $1+1=2$b
 c$x$d
 .
-<p>a<eq>1+1=2</eq>
-<eq>1+1=2</eq>b
-c<eq>x</eq>d</p>
+<p>a<span class="math inline">1+1=2</span>
+<span class="math inline">1+1=2</span>b
+c<span class="math inline">x</span>d</p>
 .
 
 following dollar character '$' is allowed. (valid=True)
 .
-$x$ $ 
+$x$ $
 .
-<p><eq>x</eq> $</p>
+<p><span class="math inline">x</span> $</p>
 .
 
 consecutive inline equations. (valid=True)
 .
 $x$ $y$
 .
-<p><eq>x</eq> <eq>y</eq></p>
+<p><span class="math inline">x</span> <span class="math inline">y</span></p>
 .
 
 inline equation after '-' sign in text. (valid=True)
 .
 so-what is $x$
 .
-<p>so-what is <eq>x</eq></p>
+<p>so-what is <span class="math inline">x</span></p>
 .
 
 display equation with line breaks. (valid=True)
@@ -203,11 +203,9 @@ $$
 1+1=2
 $$
 .
-<section>
-<eqn>
+<div class="math block">
 1+1=2
-</eqn>
-</section>
+</div>
 .
 
 multiple equations (valid=True)
@@ -220,16 +218,12 @@ $$
 b = 2
 $$
 .
-<section>
-<eqn>
+<div class="math block">
 a = 1
-</eqn>
-</section>
-<section>
-<eqn>
+</div>
+<div class="math block">
 b = 2
-</eqn>
-</section>
+</div>
 .
 
 equation followed by a labelled equation (valid=True)
@@ -242,62 +236,58 @@ $$
 b = 2
 $$ (1)
 .
-<section>
-<eqn>
+<div class="math block">
 a = 1
-</eqn>
-</section>
-<section>
-<eqn>
+</div>
+<div id="1" class="math block">
+<a href="#1" class="mathlabel" title="Permalink to this equation">¶</a>
 b = 2
-</eqn>
-<span class="eqno">(1)</span>
-</section>
+</div>
 .
 
 multiline equation. (valid=True)
 .
 $$\\begin{matrix}
- f & = & 2 + x + 3 \\ 
- & = & 5 + x 
+ f & = & 2 + x + 3 \\
+ & = & 5 + x
 \\end{matrix}$$
 .
-<section>
-<eqn>\\begin{matrix}
- f & = & 2 + x + 3 \\ 
- & = & 5 + x 
-\\end{matrix}</eqn>
-</section>
+<div class="math block">
+\\begin{matrix}
+ f &amp; = &amp; 2 + x + 3 \\
+ &amp; = &amp; 5 + x
+\\end{matrix}
+</div>
 .
 
 vector equation. (valid=True)
 .
-$$\\begin{pmatrix}x_2 \\\\ y_2 \\end{pmatrix} = 
+$$\\begin{pmatrix}x_2 \\\\ y_2 \\end{pmatrix} =
 \\begin{pmatrix} A & B \\\\ C & D \\end{pmatrix}\\cdot
 \\begin{pmatrix} x_1 \\\\ y_1 \\end{pmatrix}$$
 .
-<section>
-<eqn>\\begin{pmatrix}x_2 \\\\ y_2 \\end{pmatrix} = 
-\\begin{pmatrix} A & B \\\\ C & D \\end{pmatrix}\\cdot
-\\begin{pmatrix} x_1 \\\\ y_1 \\end{pmatrix}</eqn>
-</section>
+<div class="math block">
+\\begin{pmatrix}x_2 \\\\ y_2 \\end{pmatrix} =
+\\begin{pmatrix} A &amp; B \\\\ C &amp; D \\end{pmatrix}\\cdot
+\\begin{pmatrix} x_1 \\\\ y_1 \\end{pmatrix}
+</div>
 .
 
 display equation with equation number. (valid=True)
 .
 $$f(x) = x^2 - 1$$ (1)
 .
-<section>
-<eqn>f(x) = x^2 - 1</eqn>
-<span class="eqno">(1)</span>
-</section>
+<div id="1" class="math block">
+<a href="#1" class="mathlabel" title="Permalink to this equation">¶</a>
+f(x) = x^2 - 1
+</div>
 .
 
 inline equation following code section. (valid=True)
 .
 `code`$a-b$
 .
-<p><code>code</code><eq>a-b</eq></p>
+<p><code>code</code><span class="math inline">a-b</span></p>
 .
 
 equation following code block. (valid=True)
@@ -309,9 +299,9 @@ $$a+b$$
 .
 <pre><code>code
 </code></pre>
-<section>
-<eqn>a+b</eqn>
-</section>
+<div class="math block">
+a+b
+</div>
 .
 
 numbered equation following code block. (valid=True)
@@ -323,10 +313,10 @@ $$a+b$$(1)
 .
 <pre><code>code
 </code></pre>
-<section>
-<eqn>a+b</eqn>
-<span class="eqno">(1)</span>
-</section>
+<div id="1" class="math block">
+<a href="#1" class="mathlabel" title="Permalink to this equation">¶</a>
+a+b
+</div>
 .
 
 Equations in list. (valid=True)
@@ -336,10 +326,10 @@ Equations in list. (valid=True)
     1. $3+4$
 .
 <ol>
-<li><eq>1+2</eq></li>
-<li><eq>2+3</eq>
+<li><span class="math inline">1+2</span></li>
+<li><span class="math inline">2+3</span>
 <ol>
-<li><eq>3+4</eq></li>
+<li><span class="math inline">3+4</span></li>
 </ol>
 </li>
 </ol>
@@ -349,26 +339,26 @@ Inline sum. (valid=True)
 .
 $\\sum\_{i=1}^n$
 .
-<p><eq>\\sum\_{i=1}^n</eq></p>
+<p><span class="math inline">\\sum\_{i=1}^n</span></p>
 .
 
 Sum without equation number. (valid=True)
 .
 $$\\sum\_{i=1}^n$$
 .
-<section>
-<eqn>\\sum\_{i=1}^n</eqn>
-</section>
+<div class="math block">
+\\sum\_{i=1}^n
+</div>
 .
 
 Sum with equation number. (valid=True)
 .
 $$\\sum\_{i=1}\^n$$ (2)
 .
-<section>
-<eqn>\\sum\_{i=1}\^n</eqn>
-<span class="eqno">(2)</span>
-</section>
+<div id="2" class="math block">
+<a href="#2" class="mathlabel" title="Permalink to this equation">¶</a>
+\\sum\_{i=1}\^n
+</div>
 .
 
 equation number always vertically aligned. (valid=True)
@@ -377,24 +367,24 @@ $${\\bold e}(\\varphi) = \\begin{pmatrix}
 \\cos\\varphi\\\\\\sin\\varphi
 \\end{pmatrix}$$ (3)
 .
-<section>
-<eqn>{\\bold e}(\\varphi) = \\begin{pmatrix}
+<div id="3" class="math block">
+<a href="#3" class="mathlabel" title="Permalink to this equation">¶</a>
+{\\bold e}(\\varphi) = \\begin{pmatrix}
 \\cos\\varphi\\\\\\sin\\varphi
-\\end{pmatrix}</eqn>
-<span class="eqno">(3)</span>
-</section>
+\\end{pmatrix}
+</div>
 .
 
 inline equations in blockquote. (valid=True)
 .
-> see $a = b + c$ 
-> $c^2=a^2+b^2$ (2) 
-> $c^2=a^2+b^2$ 
+> see $a = b + c$
+> $c^2=a^2+b^2$ (2)
+> $c^2=a^2+b^2$
 .
 <blockquote>
-<p>see <eq>a = b + c</eq>
-<eq>c^2=a^2+b^2</eq> (2)
-<eq>c^2=a^2+b^2</eq></p>
+<p>see <span class="math inline">a = b + c</span>
+<span class="math inline">c^2=a^2+b^2</span> (2)
+<span class="math inline">c^2=a^2+b^2</span></p>
 </blockquote>
 .
 
@@ -404,14 +394,14 @@ display equation in blockquote. (valid=True)
 >
 > $$ a+b=c$$ (2)
 >
-> in blockquote. 
+> in blockquote.
 .
 <blockquote>
 <p>formula</p>
-<section>
-<eqn> a+b=c</eqn>
-<span class="eqno">(2)</span>
-</section>
+<div id="2" class="math block">
+<a href="#2" class="mathlabel" title="Permalink to this equation">¶</a>
+a+b=c
+</div>
 <p>in blockquote.</p>
 </blockquote>
 .
@@ -425,15 +415,13 @@ $$ (abc)
 
 - ab $c=1$ d
 .
-<section>
-<eqn>
+<div id="abc" class="math block">
+<a href="#abc" class="mathlabel" title="Permalink to this equation">¶</a>
 a=1 \\
 b=2
-</eqn>
-<span class="eqno">(abc)</span>
-</section>
+</div>
 <ul>
-<li>ab <eq>c=1</eq> d</li>
+<li>ab <span class="math inline">c=1</span> d</li>
 </ul>
 .
 
@@ -443,8 +431,8 @@ dollar '$' characters. (valid=True)
 \\$1+1=2$
 $1+1=2\\$
 .
-<p>\<eq>1+1=2</eq>
-<eq>1+1=2\\</eq></p>
+<p>\<span class="math inline">1+1=2</span>
+<span class="math inline">1+1=2\\</span></p>
 .
 
 empty line between text and display formula is required. (valid=False)
@@ -495,49 +483,49 @@ math-escaping: internal escaped $:
 .
 $p_2 = \$1$
 .
-<p><eq>p_2 = \$1</eq></p>
+<p><span class="math inline">p_2 = \$1</span></p>
 .
 
 math-escaping: double-escaped start $:
 .
 \\$p_2 = 1$
 .
-<p>\<eq>p_2 = 1</eq></p>
+<p>\<span class="math inline">p_2 = 1</span></p>
 .
 
 math-escaping: double-escaped end $:
 .
 $p_2 = \\$a
 .
-<p><eq>p_2 = \\</eq>a</p>
+<p><span class="math inline">p_2 = \\</span>a</p>
 .
 
 Inline double-dollar start:
 .
 $$a=1$$ b
 .
-<p><eqn>a=1</eqn> b</p>
+<p><div class="math inline">a=1</div> b</p>
 .
 
 Inline double-dollar end:
 .
 a $$a=1$$
 .
-<p>a <eqn>a=1</eqn></p>
+<p>a <div class="math inline">a=1</div></p>
 .
 
 Inline double-dollar enclosed:
 .
 a $$a=1$$ (1) b
 .
-<p>a <eqn>a=1</eqn> (1) b</p>
+<p>a <div class="math inline">a=1</div> (1) b</p>
 .
 
 Inline double-dollar, escaped:
 .
 a \$$a=1$$ b
 .
-<p>a $<eq>a=1</eq>$ b</p>
+<p>a $<span class="math inline">a=1</span>$ b</p>
 .
 
 Inline mixed single/double dollars:
@@ -548,9 +536,7 @@ $$
 $$
 i.e., $[\alpha \bar{X}, \infty)$ is a lower 1-sided $1-\alpha$ confidence bound for $\mu$.
 .
-<p>Hence, for <eq>\alpha \in (0, 1)</eq>,
-<eqn>
-  \mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;
-</eqn>
-i.e., <eq>[\alpha \bar{X}, \infty)</eq> is a lower 1-sided <eq>1-\alpha</eq> confidence bound for <eq>\mu</eq>.</p>
+<p>Hence, for <span class="math inline">\alpha \in (0, 1)</span>,
+<div class="math inline">\mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;</div>
+i.e., <span class="math inline">[\alpha \bar{X}, \infty)</span> is a lower 1-sided <span class="math inline">1-\alpha</span> confidence bound for <span class="math inline">\mu</span>.</p>
 .

--- a/tests/fixtures/katex.md
+++ b/tests/fixtures/katex.md
@@ -2,20 +2,24 @@ basic inline
 .
 $a$
 .
-<p><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>a</mi></mrow><annotation encoding="application/x-tex">a</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">a</span></span></span></span></p>
+<p><span class="math inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>a</mi></mrow><annotation encoding="application/x-tex">a</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">a</span></span></span></span></span></p>
 .
 
 basic block
 .
 $$a$$
 .
+<div class="math block">
 <span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>a</mi></mrow><annotation encoding="application/x-tex">a</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">a</span></span></span></span></span>
+</div>
 .
 
 labelled block
 .
 $$a$$ (label)
 .
-<span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>a</mi></mrow><annotation encoding="application/x-tex">a</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">a</span></span></span></span></span>
+<div id="label" class="math block">
 <a href="#label" class="mathlabel" title="Permalink to this equation">¶</a>
+<span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>a</mi></mrow><annotation encoding="application/x-tex">a</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">a</span></span></span></span></span>
+</div>
 .


### PR DESCRIPTION
Features:
* Wrapped all content in a div/span, if this is not desired by the user we can encourage people to overwrite the rules completely
* Removed pass-through options, see https://github.com/executablebooks/markdown-it-amsmath/issues/5
  *  This is backward compatible in most cases that use katex
* Added an ID to the element when it it labelled
* Added a `labelRenderer` to `IOptions` which allows you to override the HTML of the label.

Development:
* Added json parser to rollup, couldn't get it to build without this
* Added prettier ignore file to ensure md fixture are never corrected
* Simplified the logic around the renderer using a factory

See also:
https://github.com/executablebooks/markdown-it-amsmath/issues/1
https://github.com/executablebooks/markdown-it-amsmath/issues/5
