### PR TITLE
👌 IMPROVE: Trim surrounding whitespace of math block content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,7 @@ function math_block_dollar(
 
     const token = state.push(label ? "math_block_label" : "math_block", "math", 0)
     token.block = true
-    token.content = state.src.slice(startPos + 2, end)
+    token.content = state.src.slice(startPos + 2, end).trim()
     token.markup = "$$"
     token.map = [startLine, state.line]
     if (label) {

--- a/tests/fixtures.spec.ts
+++ b/tests/fixtures.spec.ts
@@ -48,3 +48,23 @@ describe("Parses basic", () => {
     it(name, () => expect(rendered.trim()).toEqual(expected.trim()))
   })
 })
+
+describe("Ensure parsing to mdast", () => {
+  it("trims math content", () => {
+    const mdit = MarkdownIt("commonmark").use(dollarmathPlugin, {
+      allow_space: false,
+      allow_digits: false,
+      double_inline: true,
+      allow_labels: true,
+      renderer: (content, { displayMode }) =>
+        renderToString(content, { throwOnError: false, displayMode })
+    })
+    const tokens = mdit.parse("$$\na\n$$ (label)", {})
+    console.log(tokens)
+    expect(tokens[0].tag).toEqual("math")
+    expect(tokens[0].content).toEqual("a")
+    expect(tokens[0].markup).toEqual("$$")
+    expect(tokens[0].info).toEqual("label")
+    expect(tokens[0].block).toEqual(true)
+  })
+})

--- a/tests/fixtures.spec.ts
+++ b/tests/fixtures.spec.ts
@@ -60,7 +60,6 @@ describe("Ensure parsing to mdast", () => {
         renderToString(content, { throwOnError: false, displayMode })
     })
     const tokens = mdit.parse("$$\na\n$$ (label)", {})
-    console.log(tokens)
     expect(tokens[0].tag).toEqual("math")
     expect(tokens[0].content).toEqual("a")
     expect(tokens[0].markup).toEqual("$$")


### PR DESCRIPTION
This has no change on the renderer, but does change the downstream users, we should expect that:

```
$$Ax=b$$ (label)
```

and 

```
$$
Ax=b
$$ (label)
```
Are equivalent to downstream consumers. Without the `trim`, there are extra newlines that need to be cleaned up later. 