### PR TITLE
Do not allow blank lines within $$

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -304,13 +304,16 @@ function math_block_dollar(
         start = state.bMarks[nextLine] + state.tShift[nextLine]
         end = state.eMarks[nextLine]
         if (end - start < 2) {
-          continue
+          break  // blank lines are not allowed within $$
         }
         lineText = state.src.slice(start, end)
         if (lineText.trim().endsWith("$$")) {
           haveEndMarker = true
           end = end - 2 - (lineText.length - lineText.trim().length)
           break
+        }
+        if (lineText.trim() == "") {
+          break  // blank lines are not allowed within $$
         }
         if (options.allow_labels) {
           const output = matchLabel(lineText, end)

--- a/tests/fixtures/basic.md
+++ b/tests/fixtures/basic.md
@@ -226,6 +226,17 @@ b = 2
 </div>
 .
 
+display equation with blank lines. (valid=False)
+.
+$$
+1+1=2
+
+$$
+.
+<p>$$1+1=2</p>
+<p>$$</p>
+.
+
 equation followed by a labelled equation (valid=True)
 .
 $$


### PR DESCRIPTION
This matches the behavior of LaTeX (and of the stackexchange and github markdown parsers), and prevents runaway parsing if a $$ is opened but not closed.